### PR TITLE
Add config option to specify a custom internal WOPI host

### DIFF
--- a/config/wopi.php
+++ b/config/wopi.php
@@ -12,6 +12,7 @@ return [
      * Default UI langauge.
      */
     'ui_language' => 'en-US',
+
     /*
      * Here, you can customize how would you like to retrive
      * all of the diffrent configration options.
@@ -41,6 +42,12 @@ return [
      * Collabora or Microsoft Office 365 or any WOPI client url.
      */
     'client_url' => env('WOPI_CLIENT_URL', ''),
+
+    /*
+     * WOPI host url override, e.g. in case the WOPI host should be accessed via an internal address instead the
+     * public one.
+     */
+    'host_url' => env('WOPI_HOST_URL', ''),
 
     /*
      * Tells the WOPI client when an access token expires, represented as

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -53,10 +53,16 @@ return [
      */
     'middleware' => [Nagi\LaravelWopi\Http\Middleware\ValidateProof::class],
 
-     /*
+    /*
      * Collabora or Microsoft Office 365 or any WOPI client url.
      */
     'client_url' => env('WOPI_CLIENT_URL', ''),
+
+    /*
+     * WOPI host url override, e.g. in case the WOPI host should be accessed via an internal address instead the
+     * public one.
+     */
+    'host_url' => env('WOPI_HOST_URL', ''),
 
     /*
      * Tells the WOPI client when an access token expires, represented as

--- a/src/Contracts/AbstractDocumentManager.php
+++ b/src/Contracts/AbstractDocumentManager.php
@@ -5,6 +5,7 @@ namespace Nagi\LaravelWopi\Contracts;
 use Closure;
 use Exception;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\URL;
 use Nagi\LaravelWopi\Contracts\Traits\SupportLocks;
 use Nagi\LaravelWopi\Facades\Discovery;
 
@@ -277,12 +278,19 @@ abstract class AbstractDocumentManager
 
         $actionUrl = optional(Discovery::discoverAction($extension, $action));
 
+        /** @var ConfigRepositoryInterface */
+        $config = app(ConfigRepositoryInterface::class);
+
+        $hasHostOverride = $config->getWopiHostUrl() ? true : false;
+        if ($hasHostOverride) {
+            URL::forceRootUrl($config->getWopiHostUrl());
+        }
         $url = route('wopi.checkFileInfo', [
             'file_id' => $this->id(),
         ]);
-
-        /** @var ConfigRepositoryInterface */
-        $config = app(ConfigRepositoryInterface::class);
+        if ($hasHostOverride) {
+            URL::forceRootUrl(null);
+        }
 
         $lang = empty($lang) ? $config->getDefaultUiLang() : $lang;
 

--- a/src/Contracts/ConfigRepositoryInterface.php
+++ b/src/Contracts/ConfigRepositoryInterface.php
@@ -6,6 +6,8 @@ interface ConfigRepositoryInterface
 {
     public function getWopiClientUrl(): string;
 
+    public function getWopiHostUrl(): string;
+
     public function getDefaultUiLang(): string;
 
     public function getDiscoveryXMLConfigFile(): ?string;

--- a/src/Services/DefaultConfigRepository.php
+++ b/src/Services/DefaultConfigRepository.php
@@ -59,6 +59,11 @@ class DefaultConfigRepository implements ConfigRepositoryInterface
         return config('wopi.client_url');
     }
 
+    public function getWopiHostUrl(): string
+    {
+        return config('wopi.host_url');
+    }
+
     public function getDefaultUser(): string
     {
         return config('wopi.default_user');

--- a/tests/Implementations/TestingConfigRepositroy.php
+++ b/tests/Implementations/TestingConfigRepositroy.php
@@ -11,6 +11,11 @@ class TestingConfigRepositroy implements ConfigRepositoryInterface
         return '';
     }
 
+    public function getWopiHostUrl(): string
+    {
+        return '';
+    }
+
     public function getDefaultUiLang(): string
     {
         return '';


### PR DESCRIPTION
When using a client-server architecture, allow specifying the API endpoint, so a direct communication between API and WOPI client is possible.