### PR TITLE
Allow resolving the username using the access token

### DIFF
--- a/docs/docs/getting-started/document-manager.md
+++ b/docs/docs/getting-started/document-manager.md
@@ -83,6 +83,8 @@ class DBDocumentManager extends AbstractDocumentManager
     public function userFriendlyName(): string
     {
         $user = Auth::user();
+        
+        // You can also use `$this->accessToken` to resolve the username using the access token.
 
         return is_null($user) ? 'Guest' : $user->name;
     }

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -45,7 +45,7 @@ WOPI_CLIENT_URL="https://demo.eu.collaboraonline.com"
 
 Every application has it's own implementation of how it handles documents, It's pretty much impossible to implement one general purpose document manager that fits all usecases. So you **Need** to implement your own `DocumentManager` but don't you worry this package provides a `AbstractDocumentManager` that will ease your task quite a bit.
 
-Take this example implementation from [Laravel wopi example](https://github.com/nagi1/laravel-wopi-example).
+Take this example implementation from [Laravel wopi example](https://github.com/nagi1/wopi-host-example).
 
 - See [Document Manager Section](document-manager#example-document-manager-implementation) for more details about `AbstractDocumentManager`.
 
@@ -126,16 +126,17 @@ For example
 
 ## 5-Retrive your document
 
-Query your document manager to get any [supported Docuemnt](#) like so
+Query your document manager to get any [supported Document](#) like so
 
 ```php
 // In web.php/your controller
 Route::get('/', function (Request $request) {
     $document = app(AbstractDocumentManager::class)::find(1);
 
-    // implementing access tokens is left to you!
+    // Implementing access tokens is left to you!
     $accessToken = 'My_Token';
-    $ttl = 0;
+    // The TTL actually is an expiry, a unix timestamp in milliseconds.
+    $ttl = (time() + 60*60) * 1000;
 
     return view('laravel-wopi-test', [
         'accessToken' => $accessToken,

--- a/src/Contracts/AbstractDocumentManager.php
+++ b/src/Contracts/AbstractDocumentManager.php
@@ -87,6 +87,14 @@ abstract class AbstractDocumentManager
     protected $userId = '';
 
     /**
+     * The access token.
+     * Note: This is not assured to be set {@see \Nagi\LaravelWopi\LaravelWopi}!
+     *
+     * @var string|null
+     */
+    protected $accessToken = null;
+
+    /**
      * Preform look up for the file/document.
      *
      * @param  string  $fileId  unique ID, Represent a single file and URL safe.
@@ -388,5 +396,13 @@ abstract class AbstractDocumentManager
         }
 
         return $response;
+    }
+
+    /**
+     * Just sets the access token.
+     */
+    public function setAccessToken(string $accessToken): void
+    {
+        $this->accessToken = $accessToken;
     }
 }

--- a/src/LaravelWopi.php
+++ b/src/LaravelWopi.php
@@ -19,6 +19,8 @@ class LaravelWopi implements WopiInterface
 
         $document = $documentManager::find($fileId);
 
+        $document->setAccessToken($accessToken);
+
         return response()->json($document->getResponseProprties());
     }
 


### PR DESCRIPTION
Since it might be tricky to resolve the username via e.g. `Auth::user()`, provide the access token to the `DocumentManager`, so the username can be resolved from that.

Also fixing some pitfalls in the docu :)